### PR TITLE
Include GetVersion methon on DomainEvent

### DIFF
--- a/src/Domain/DomainEvent.php
+++ b/src/Domain/DomainEvent.php
@@ -11,6 +11,8 @@ namespace StraTDeS\SharedKernel\Domain;
 
 abstract class DomainEvent
 {
+    const EVENT_VERSION = 1;
+    
     /** @var Id */
     private $id;
 
@@ -78,10 +80,13 @@ abstract class DomainEvent
     {
         return $this->createdAt;
     }
+    
+    public function getVersion(): int
+    {
+        return static::EVENT_VERSION;
+    }
 
     public abstract function getCode(): string;
-
-    public abstract function getVersion(): int;
 
     public abstract function getData(): array;
 

--- a/src/Domain/DomainEvent.php
+++ b/src/Domain/DomainEvent.php
@@ -12,7 +12,7 @@ namespace StraTDeS\SharedKernel\Domain;
 abstract class DomainEvent
 {
     const EVENT_VERSION = 1;
-    
+
     /** @var Id */
     private $id;
 
@@ -76,17 +76,20 @@ abstract class DomainEvent
         return $this->creator;
     }
 
+    public function getCode(): string
+    {
+        return strtoupper(preg_replace('/(?<!^)[A-Z]/', '_$0', current(array_reverse(explode("\\",get_called_class())))));
+    }
+
     final public function getCreatedAt(): \DateTime
     {
         return $this->createdAt;
     }
-    
+
     public function getVersion(): int
     {
         return static::EVENT_VERSION;
     }
-
-    public abstract function getCode(): string;
 
     public abstract function getData(): array;
 


### PR DESCRIPTION
Define getVersion method on DomainEvent so we don't have to implement getVersion on each child class (which usually is always the same).